### PR TITLE
Switch from paths to hosts

### DIFF
--- a/Proxy/appsettings.json
+++ b/Proxy/appsettings.json
@@ -14,30 +14,20 @@
       "minimumroute": {
         "ClusterId": "main",
         "Match": {
-          "Path": "{**catch-all}"
+          "Hosts" : [ "*.site.com" ],
         }
       },
       "subsite1": {
         "ClusterId": "subsite1",
         "Match": {
-          "Path": "/subsite1/{**catch-all}"
-        },
-        "Transforms": [
-          {
-            "PathRemovePrefix": "/subsite1"
-          }
-        ]
+          "Hosts" : [ "subsite1.site.com" ],
+        }
       },
       "subsite2": {
         "ClusterId": "subsite2",
         "Match": {
-          "Path": "/subsite2/{**catch-all}"
-        },
-        "Transforms": [
-          {
-            "PathRemovePrefix": "/subsite2"
-          }
-        ]
+          "Hosts" : [ "subsite2.site.com" ],
+        }
       }
     },
     "Clusters": {


### PR DESCRIPTION
Path routing breaks link generation and static assets. Best to use a subdomain instead.